### PR TITLE
remove eth_estimateGas to allow smart contracts

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -473,9 +473,7 @@ export type SuccessResponse<T = MethodToResponse[Methods]> = {
 };
 export declare const RPC_CALLS: {
   readonly eth_call: "eth_call";
-  readonly eth_gasPrice: "eth_gasPrice";
   readonly eth_getLogs: "eth_getLogs";
-  readonly eth_getBalance: "eth_getBalance";
   readonly eth_getCode: "eth_getCode";
   readonly eth_getBlockByHash: "eth_getBlockByHash";
   readonly eth_getBlockByNumber: "eth_getBlockByNumber";
@@ -483,7 +481,6 @@ export declare const RPC_CALLS: {
   readonly eth_getTransactionByHash: "eth_getTransactionByHash";
   readonly eth_getTransactionReceipt: "eth_getTransactionReceipt";
   readonly eth_getTransactionCount: "eth_getTransactionCount";
-  readonly eth_estimateGas: "eth_estimateGas";
 };
 
 export declare type RpcCallNames = keyof typeof RPC_CALLS;


### PR DESCRIPTION
Let the end client call the gas estimations instead of this sdk and send it back through postMessage.

We use smart contracts with paymaster accounts. Gas estimation call always fail as a result.